### PR TITLE
Use Tensor.cpu() to fix device type error

### DIFF
--- a/tutorial/object_detection/object_detection.ipynb
+++ b/tutorial/object_detection/object_detection.ipynb
@@ -389,7 +389,7 @@
     "\n",
     "    def draw_detection(self, img_tensor, bboxes, labels, scores, out_img_file):\n",
     "        \"\"\"Draw detection result.\"\"\"\n",
-    "        img_array = img_tensor.permute(1, 2, 0).numpy() * 255\n",
+    "        img_array = img_tensor.cpu().permute(1, 2, 0).numpy() * 255\n",
     "        img = Image.fromarray(img_array.astype(np.uint8))\n",
     "        \n",
     "        draw = ImageDraw.Draw(img)    \n",


### PR DESCRIPTION
object-detection 예제 코드를 사용하고 cuda로 모델을 저장하려고 하는 경우에
발생하는 아래 에러를 해결하고자 합니다.

![스크린샷 2024-04-01 오후 5 14 15](https://github.com/makinarocks/runway-tutorial/assets/88356355/46ce4774-16fa-4078-93a1-7a7ccb846aca)

재현 방법:
1. gpu 1개짜리 instance type 으로 dev instance 생성
2. object-detection.ipynb 실행
3. gpu 를 사용하는 모델을 저장하기 위해 "show sample inference" 에서 아래와 같이 cuda 로 코드 수정

```
model = model.cuda()
device = "cuda"
serve_model = ModelWrapper(model=model, device=device)
```

4. dataset은 tutorial/object_detection/dataset 폴더 사용하도록 지정하고 파이프라인 실행

5. 위처럼 에러 발생

6. pr 과 같이 수정하면 pipeline 실행에 성공하고 model deployment 도 가능함. model 을 cpu 로 저장할 때도 pipeline 실행 성공함